### PR TITLE
Implement better errors and change MOVW instruction to parse as it does with AVRA

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ You can find test assembly programs in the `test_files/` directory in the root o
   - [x] Implement Parser support for lowercase instructions.
   - [x] Implementing `ADIW`.
   - [x] Unit tests for instructions.
+  - [x] Better error reporting.
   - [ ] Implement limitations to instructions similar to real hardware.
-  - [ ] Better error reporting
   - [ ] Add more to the roadmap.
   - [ ] Buy Grolsch beer when this is all done :tada: :beer:
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,7 +1,6 @@
 module Main where
 
 import Options.Applicative
-import Text.Megaparsec.Error
 import Emulator
 import Parser
 import Options
@@ -24,7 +23,7 @@ assembleProgramFromFile filename = do
     contents <- readFile filename
     case parseAssembly contents of
         Left err -> do
-            putStrLn $ errorBundlePretty err
+            putStrLn $ prettyPrintErrorBundle err
             return Nothing
         Right instructions -> return (Just instructions)
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -28,14 +28,14 @@ assembleProgramFromFile filename = do
             return Nothing
         Right instructions -> return (Just instructions)
 
-compileFromFile :: FilePath -> Bool -> Int -> IO (Either String EmulatorState)
+compileFromFile :: FilePath -> Bool -> Int -> IO (Maybe EmulatorState)
 compileFromFile input False memorySize = do
     maybeInstructions <- assembleProgramFromFile input
     case maybeInstructions of
         Just instructions -> do
             let finalState = run instructions memorySize
-            return (Right finalState)
-        Nothing -> (return (Left "Error assembling the program"))
+            return (Just finalState)
+        Nothing -> return Nothing
 
 compileFromFile input True memorySize = do
     maybeInstructions <- assembleProgramFromFile input
@@ -43,8 +43,8 @@ compileFromFile input True memorySize = do
         Just instructions -> do
             mapM_ print (replaceLabels instructions)
             let finalState = run instructions memorySize
-            return (Right finalState)
-        Nothing -> (return (Left "Error assembling the program"))
+            return (Just finalState)
+        Nothing -> return Nothing
 
 getVersion :: String
 getVersion = showVersion version
@@ -63,21 +63,21 @@ entryFunction (Options _ _ _ _ False Nothing) = error "You did not supply a file
 entryFunction (Options False dmpIR memorySize False _ (Just filepath)) = do
     finalState <- compileFromFile filepath dmpIR memorySize
     case finalState of
-        Right state -> do
+        Just state -> do
             printRegisterBank $ registers state         -- Pretty print the register banks
             putStrLn (showStatusFlags $ flags state)    -- Print the final status flags
-        Left errorMessage -> print errorMessage
+        Nothing -> return ()
 
 -- | Supplied file, will dump SRAM to stdout
 entryFunction (Options True dmpIR memorySize False _ (Just filepath)) = do
     finalState <- compileFromFile filepath dmpIR memorySize
     case finalState of
-        Right state -> do
+        Just state -> do
             prettyPrintMemory (memory state)            -- Pretty print the memory
             putStrLn ""
             printRegisterBank $ registers state         -- Pretty print the register banks
             putStrLn (showStatusFlags $ flags state)    -- Print the final status flags
-        Left errorMessage -> print errorMessage
+        Nothing -> return ()
 
 -- | Ignore dump memory and dump IR flags, start a REPL for an interactive session
 entryFunction (Options _ _ memorySize True False (Just filepath)) = do

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,6 +1,7 @@
 module Main where
 
 import Options.Applicative
+import Text.Megaparsec.Error
 import Emulator
 import Parser
 import Options
@@ -23,7 +24,7 @@ assembleProgramFromFile filename = do
     contents <- readFile filename
     case parseAssembly contents of
         Left err -> do
-            print err
+            putStrLn $ errorBundlePretty err
             return Nothing
         Right instructions -> return (Just instructions)
 

--- a/avr-emulator.cabal
+++ b/avr-emulator.cabal
@@ -84,7 +84,6 @@ executable avr-emulator
     -- Other library packages from which modules are imported.
     build-depends:      base >=4.16.2.1
                         , optparse-applicative >= 0.18.1.0
-                        , megaparsec >=9.7.0
                         , avr-emulator
 
     -- Base language which the package is written in.

--- a/avr-emulator.cabal
+++ b/avr-emulator.cabal
@@ -84,6 +84,7 @@ executable avr-emulator
     -- Other library packages from which modules are imported.
     build-depends:      base >=4.16.2.1
                         , optparse-applicative >= 0.18.1.0
+                        , megaparsec >=9.7.0
                         , avr-emulator
 
     -- Base language which the package is written in.

--- a/src/Emulator/Instructions.hs
+++ b/src/Emulator/Instructions.hs
@@ -77,6 +77,7 @@ data Instruction
     | CLV
     | CLZ
     | COM Register
+    | Comment
     | CP Register Register
     | CPC Register Register
     | CPI Register Word8

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -116,9 +116,12 @@ pDecimal = do
     digits <- some digitChar
     return (read digits)
 
+pLabelValue :: Parser String
+pLabelValue = some (alphaNumChar <|> char '_')
+
 pLabel :: Parser Instruction
 pLabel = do
-    label <- some (alphaNumChar <|> char '_')
+    label <- pLabelValue
     char ':'
     return (LABEL label)
 
@@ -189,115 +192,115 @@ pBLD = do
 pBRCC :: Parser Instruction
 pBRCC = do
     cistring "BRCC" >> space
-    label <- some (alphaNumChar <|> char '_')
+    label <- pLabelValue
     return (BRCC label)
 
 pBRCS :: Parser Instruction
 pBRCS = do
     cistring "BRCS" >> space
-    label <- some (alphaNumChar <|> char '_')
+    label <- pLabelValue
     return (BRCS label)
 
 pBREQ :: Parser Instruction
 pBREQ = do
     cistring "BREQ" >> space
-    label <- some (alphaNumChar <|> char '_')
+    label <- pLabelValue
     return (BREQ label)
 
 pBRGE :: Parser Instruction
 pBRGE = do
     cistring "BRGE" >> space
-    label <- some (alphaNumChar <|> char '_')
+    label <- pLabelValue
     return (BRGE label)
 
 pBRHC :: Parser Instruction
 pBRHC = do
     cistring "BRHC" >> space
-    label <- some (alphaNumChar <|> char '_')
+    label <- pLabelValue
     return (BRHC label)
 
 pBRHS :: Parser Instruction
 pBRHS = do
     cistring "BRHS" >> space
-    label <- some (alphaNumChar <|> char '_')
+    label <- pLabelValue
     return (BRHS label)
 
 pBRID :: Parser Instruction
 pBRID = do
     cistring "BRID" >> space
-    label <- some (alphaNumChar <|> char '_')
+    label <- pLabelValue
     return (BRID label)
 
 pBRIE :: Parser Instruction
 pBRIE = do
     cistring "BRIE" >> space
-    label <- some (alphaNumChar <|> char '_')
+    label <- pLabelValue
     return (BRIE label)
 
 pBRLO :: Parser Instruction
 pBRLO = do
     cistring "BRLO" >> space
-    label <- some (alphaNumChar <|> char '_')
+    label <- pLabelValue
     return (BRLO label)
 
 pBRLT :: Parser Instruction
 pBRLT = do
     cistring "BRLT" >> space
-    label <- some (alphaNumChar <|> char '_')
+    label <- pLabelValue
     return (BRLT label)
 
 pBRMI :: Parser Instruction
 pBRMI = do
     cistring "BRMI" >> space
-    label <- some (alphaNumChar <|> char '_')
+    label <- pLabelValue
     return (BRMI label)
 
 pBRNE :: Parser Instruction
 pBRNE = do
     cistring "BRNE" >> space
-    label <- some (alphaNumChar <|> char '_')
+    label <- pLabelValue
     return (BRNE label)
 
 pBRPL :: Parser Instruction
 pBRPL = do
     cistring "BRPL" >> space
-    label <- some (alphaNumChar <|> char '_')
+    label <- pLabelValue
     return (BRPL label)
 
 pBRSH :: Parser Instruction
 pBRSH = do
     cistring "BRSH" >> space
-    label <- some (alphaNumChar <|> char '_')
+    label <- pLabelValue
     return (BRSH label)
 
 pBRTC :: Parser Instruction
 pBRTC = do
     cistring "BRTC" >> space
-    label <- some (alphaNumChar <|> char '_')
+    label <- pLabelValue
     return (BRTC label)
 
 pBRTS :: Parser Instruction
 pBRTS = do
     cistring "BRTS" >> space
-    label <- some (alphaNumChar <|> char '_')
+    label <- pLabelValue
     return (BRTS label)
 
 pBRVC :: Parser Instruction
 pBRVC = do
     cistring "BRVC" >> space
-    label <- some (alphaNumChar <|> char '_')
+    label <- pLabelValue
     return (BRVC label)
 
 pBRVS :: Parser Instruction
 pBRVS = do
     cistring "BRVS" >> space
-    label <- some (alphaNumChar <|> char '_')
+    label <- pLabelValue
     return (BRVS label)
 
 pCALL :: Parser Instruction
 pCALL = do
     cistring "CALL" >> space
-    label <- some (alphaNumChar <|> char '_')
+    label <- pLabelValue
     return (CALL label)
 
 pCBR :: Parser Instruction
@@ -406,7 +409,7 @@ pINC = do
 pJMP :: Parser Instruction
 pJMP = do
     cistring "JMP" >> space
-    label <- some (alphaNumChar <|> char '_')
+    label <- pLabelValue
     return (JMP label)
 
 pLD :: Parser Instruction
@@ -713,20 +716,20 @@ instructionParser = do
         pTST
         ]
 
--- Parser for comments
+-- | Parser for comments
 commentParser :: Parser (Instruction)
 commentParser = do
     _ <- char ';'  -- Skip the comment start
     choice [
         try (manyTill printChar eol),
         manyTill printChar eof]  -- Consume the comment content
-    return (Comment)  -- Always return Nothing for comments
+    return (Comment)  -- Return the comment instruction type, which will get filtered out
 
--- Parser for a line (either an instruction or a comment)
+-- | Parser for a line. First tries a label, if that fails, it backtracks and tries either an instruction or a comment
 lineParser :: Parser (Instruction)
 lineParser = (try pLabel) <|> (instructionParser <?> "instruction") <|> (commentParser <?> "comment")
 
--- Parser for a list of instructions
+-- | Parser for a list of instructions
 programParser :: Parser [Instruction]
 programParser = do
     instructions <- many (space *> lineParser <* space)

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -11,7 +11,6 @@ import Data.Void
 import Data.Binary
 import Data.Char
 import Numeric (readHex)
-import Data.Maybe (catMaybes)
 
 import Emulator
 
@@ -612,115 +611,117 @@ pTST = do
 
 -- Main parsers
 
-instructionParser :: Parser (Maybe Instruction)
+instructionParser :: Parser (Instruction)
 instructionParser = do
     space
     choice
         [
-        try (Just <$> pADC),
-        try (Just <$> pADD),
-        try (Just <$> pADIW),
-        try (Just <$> pAND),
-        try (Just <$> pANDI),
-        try (Just <$> pASR),
-        try (Just <$> pBCLR),
-        try (Just <$> pBLD),
-        try (Just <$> pBRCC),
-        try (Just <$> pBRCS),
-        try (Just <$> pBREQ),
-        try (Just <$> pBRGE),
-        try (Just <$> pBRHC),
-        try (Just <$> pBRHS),
-        try (Just <$> pBRID),
-        try (Just <$> pBRIE),
-        try (Just <$> pBRLO),
-        try (Just <$> pBRLT),
-        try (Just <$> pBRMI),
-        try (Just <$> pBRNE),
-        try (Just <$> pBRPL),
-        try (Just <$> pBRSH),
-        try (Just <$> pBRTC),
-        try (Just <$> pBRTS),
-        try (Just <$> pBRVC),
-        try (Just <$> pBRVS),
-        try (Just <$> pCALL),
-        try (Just <$> pCBR),
-        try (Just <$> pCLC),
-        try (Just <$> pCLH),
-        try (Just <$> pCLI),
-        try (Just <$> pCLN),
-        try (Just <$> pCLR),
-        try (Just <$> pCLS),
-        try (Just <$> pCLT),
-        try (Just <$> pCLV),
-        try (Just <$> pCLZ),
-        try (Just <$> pCOM),
-        try (Just <$> pCP),
-        try (Just <$> pCPC),
-        try (Just <$> pCPI),
-        try (Just <$> pCPSE),
-        try (Just <$> pDEC),
-        try (Just <$> pEOR),
-        try (Just <$> pINC),
-        try (Just <$> pJMP),
-        try (Just <$> pLD),
-        try (Just <$> pLabel),
-        try (Just <$> pLDI),
-        try (Just <$> pLDS),
-        try (Just <$> pLSL),
-        try (Just <$> pLSR),
-        try (Just <$> pMOV),
-        try (Just <$> pMOVW),
-        try (Just <$> pMUL),
-        try (Just <$> pMULS),
-        try (Just <$> pNEG),
-        try (Just <$> pNOP),
-        try (Just <$> pOR),
-        try (Just <$> pORI),
-        try (Just <$> pPOP),
-        try (Just <$> pPUSH),
-        try (Just <$> pRET),
-        try (Just <$> pROL),
-        try (Just <$> pROR),
-        try (Just <$> pSBC),
-        try (Just <$> pSBRC),
-        try (Just <$> pSBRS),
-        try (Just <$> pSEC),
-        try (Just <$> pSEH),
-        try (Just <$> pSEI),
-        try (Just <$> pSEN),
-        try (Just <$> pSER),
-        try (Just <$> pSES),
-        try (Just <$> pSET),
-        try (Just <$> pSEV),
-        try (Just <$> pSEZ),
-        try (Just <$> pST),
-        try (Just <$> pSTS),
-        try (Just <$> pSUB),
-        try (Just <$> pSUBI),
-        try (Just <$> pSWAP),
-        try (Just <$> pTST)
+        pADC,
+        pADD,
+        pADIW,
+        pANDI,
+        pAND,
+        pASR,
+        pBCLR,
+        pBLD,
+        pBRCC,
+        pBRCS,
+        pBREQ,
+        pBRGE,
+        pBRHC,
+        pBRHS,
+        pBRID,
+        pBRIE,
+        pBRLO,
+        pBRLT,
+        pBRMI,
+        pBRNE,
+        pBRPL,
+        pBRSH,
+        pBRTC,
+        pBRTS,
+        pBRVC,
+        pBRVS,
+        pCALL,
+        pCBR,
+        pCLC,
+        pCLH,
+        pCLI,
+        pCLN,
+        pCLR,
+        pCLS,
+        pCLT,
+        pCLV,
+        pCLZ,
+        pCOM,
+        pCPSE,
+        pCPC,
+        pCPI,
+        pCP,
+        pDEC,
+        pEOR,
+        pINC,
+        pJMP,
+        pLDI,
+        pLDS,
+        pLD,
+        pLSL,
+        pLSR,
+        pMOVW,
+        pMOV,
+        pMULS,
+        pMUL,
+        pNEG,
+        pNOP,
+        pORI,
+        pOR,
+        pPOP,
+        pPUSH,
+        pRET,
+        pROL,
+        pROR,
+        pSBC,
+        pSBRC,
+        pSBRS,
+        pSEC,
+        pSEH,
+        pSEI,
+        pSEN,
+        pSER,
+        pSES,
+        pSET,
+        pSEV,
+        pSEZ,
+        pSTS,
+        pST,
+        pSUBI,
+        pSUB,
+        pSWAP,
+        pTST
         ]
 
 -- Parser for comments
-commentParser :: Parser (Maybe Instruction)
+commentParser :: Parser (Instruction)
 commentParser = do
     _ <- char ';'  -- Skip the comment start
     choice [
         try (manyTill printChar eol),
         manyTill printChar eof]  -- Consume the comment content
-    return Nothing  -- Always return Nothing for comments
+    return (Comment)  -- Always return Nothing for comments
 
 -- Parser for a line (either an instruction or a comment)
-lineParser :: Parser (Maybe Instruction)
-lineParser = try instructionParser <|> try commentParser
+lineParser :: Parser (Instruction)
+lineParser = (try pLabel) <|> (instructionParser <?> "instruction") <|> (commentParser <?> "comment")
 
 -- Parser for a list of instructions
 programParser :: Parser [Instruction]
 programParser = do
     instructions <- many (space *> lineParser <* space)
     eof
-    return (catMaybes instructions)
+    return (filter isNotComment instructions)
+    where
+        isNotComment (Comment) = False
+        isNotComment _ = True
 
 -- Run the parser on the input
 parseAssembly :: String -> Either (ParseErrorBundle T.Text Void) [Instruction]

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -55,11 +55,8 @@ pRegister = do
 
 pRegisterPair :: Parser (Register, Register)
 pRegisterPair = do
-    cichar 'R'
-    reg1 <- some digitChar
-    char ':'
-    reg2 <- some digitChar
-    return (read reg1, read reg2)
+    reg <- pRegister
+    return (reg+1, reg)
 
 pHexDigit :: Parser Char
 pHexDigit = oneOf ['0'..'9'] <|> oneOf ['a'..'f'] <|> oneOf ['A'..'F']
@@ -147,12 +144,12 @@ pADD = do
 pADIW :: Parser Instruction
 pADIW = do
     cistring "ADIW" >> space
-    reg1 <- pRegister
+    (reg1, reg2) <- pRegisterPair
     pComma
-    if isValidRegister reg1 then
-        ADIW (reg1 + 1) reg1 <$> pWord8
+    if isValidRegister reg2 then
+        ADIW reg1 reg2 <$> pWord8
     else
-        fail "Must be register 26, 28 or 30."
+        fail "Register must be R24, R26, R28 or R30."
     where
     isValidRegister r
         | r == 24 || r == 26 || r == 28 || r == 30 = True
@@ -456,7 +453,14 @@ pMOVW = do
     (reg1, reg2) <- pRegisterPair
     pComma
     (reg3, reg4) <- pRegisterPair
-    return (MOVW reg1 reg2 reg3 reg4)
+    if isValidRegister reg2 && isValidRegister reg4 then
+        return (MOVW reg1 reg2 reg3 reg4)
+    else
+        fail "Register has to be R{0,2,..,30}"
+    where
+    isValidRegister r
+        | r `mod` 2 == 0 && r >= 0 && r < 32 = True
+        | otherwise = False
 
 pMUL :: Parser Instruction
 pMUL = do

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -47,8 +47,11 @@ pNumberedRegister = do
 
 pRegister :: Parser Register
 pRegister = do
-  reg <- choice [try pNumberedRegister, try pLabelledRegister]
-  return reg
+  reg <- choice [try pNumberedRegister , try pLabelledRegister] <?> "register"
+  if reg < 0 || reg >= 32 then
+    fail "Register number can't be outside the range [0..31]"
+  else
+    return reg
 
 pRegisterPair :: Parser (Register, Register)
 pRegisterPair = do
@@ -64,16 +67,26 @@ pHexDigit = oneOf ['0'..'9'] <|> oneOf ['a'..'f'] <|> oneOf ['A'..'F']
 pFlagDigit :: Parser Int
 pFlagDigit = digitToInt <$> oneOf ['0'..'7']
 
-pWord8 :: Parser Word8
-pWord8 = do
+pHexWord8 :: Parser Word8
+pHexWord8 = do
     string "0x" <|> string "$"
     hexDigits <- some pHexDigit
     case readHex hexDigits of
-        [(value, "")] ->
-            if 0 <= value && value <= 0xFF
-                then return (fromInteger value)
-            else fail "Hexadecimal value out of range for Word8"
-        _ -> fail "Invalid hexadecimal format"
+        [(value, "")] -> return (fromInteger value)
+        _ -> fail "Invalid hexadecimal number format"
+
+pDecWord8 :: Parser Word8
+pDecWord8 = do
+    digits <- some digitChar
+    return $ read digits
+
+pWord8 :: Parser Word8
+pWord8 = do
+    byte <- pHexWord8 <|> pDecWord8 <?> "number in hexadecimal or decimal format"
+    if 0 <= byte && byte <= 0xFF then
+        return byte
+    else
+        fail "Value out of range for a byte"
 
 pWord16 :: Parser Word16
 pWord16 = do

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 
-module Parser(parseAssembly) where
+module Parser(parseAssembly, prettyPrintErrorBundle) where
 
 import Text.Megaparsec
 import Text.Megaparsec.Char
@@ -742,6 +742,9 @@ programParser = do
     where
         isNotComment (Comment) = False
         isNotComment _ = True
+
+prettyPrintErrorBundle :: ParseErrorBundle T.Text Void -> String
+prettyPrintErrorBundle = errorBundlePretty
 
 -- Run the parser on the input
 parseAssembly :: String -> Either (ParseErrorBundle T.Text Void) [Instruction]

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -129,21 +129,21 @@ pComma = char ',' >> space
 
 pADC :: Parser Instruction
 pADC = do
-    cistring "ADC" >> space
+    cistring "ADC" >> space1
     rd <- pRegister
     pComma
     ADC rd <$> pRegister
 
 pADD :: Parser Instruction
 pADD = do
-    cistring "ADD" >> space
+    cistring "ADD" >> space1
     rd <- pRegister
     pComma
     ADD rd <$> pRegister
 
 pADIW :: Parser Instruction
 pADIW = do
-    cistring "ADIW" >> space
+    cistring "ADIW" >> space1
     (reg1, reg2) <- pRegisterPair
     pComma
     if isValidRegister reg2 then
@@ -157,299 +157,298 @@ pADIW = do
 
 pAND :: Parser Instruction
 pAND = do
-    cistring "AND" >> space
+    cistring "AND" >> space1
     rd <- pRegister
     pComma
     AND rd <$> pRegister
 
 pANDI :: Parser Instruction
 pANDI = do
-    cistring "ANDI" >> space
+    cistring "ANDI" >> space1
     rd <- pRegister
     pComma
     ANDI rd <$> pWord8
 
 pASR :: Parser Instruction
 pASR = do
-    cistring "ASR" >> space
+    cistring "ASR" >> space1
     ASR <$> pRegister
 
 pBCLR :: Parser Instruction
 pBCLR = do
-    cistring "BCLR" >> space
+    cistring "BCLR" >> space1
     BCLR <$> pFlagDigit
 
 pBLD :: Parser Instruction
 pBLD = do
-    cistring "BLD" >> space
+    cistring "BLD" >> space1
     rd <- pRegister
     pComma
     BLD rd <$> pFlagDigit
 
 pBRCC :: Parser Instruction
 pBRCC = do
-    cistring "BRCC" >> space
+    cistring "BRCC" >> space1
     label <- pLabelValue
     return (BRCC label)
 
 pBRCS :: Parser Instruction
 pBRCS = do
-    cistring "BRCS" >> space
+    cistring "BRCS" >> space1
     label <- pLabelValue
     return (BRCS label)
 
 pBREQ :: Parser Instruction
 pBREQ = do
-    cistring "BREQ" >> space
+    cistring "BREQ" >> space1
     label <- pLabelValue
     return (BREQ label)
 
 pBRGE :: Parser Instruction
 pBRGE = do
-    cistring "BRGE" >> space
+    cistring "BRGE" >> space1
     label <- pLabelValue
     return (BRGE label)
 
 pBRHC :: Parser Instruction
 pBRHC = do
-    cistring "BRHC" >> space
+    cistring "BRHC" >> space1
     label <- pLabelValue
     return (BRHC label)
 
 pBRHS :: Parser Instruction
 pBRHS = do
-    cistring "BRHS" >> space
+    cistring "BRHS" >> space1
     label <- pLabelValue
     return (BRHS label)
 
 pBRID :: Parser Instruction
 pBRID = do
-    cistring "BRID" >> space
+    cistring "BRID" >> space1
     label <- pLabelValue
     return (BRID label)
 
 pBRIE :: Parser Instruction
 pBRIE = do
-    cistring "BRIE" >> space
+    cistring "BRIE" >> space1
     label <- pLabelValue
     return (BRIE label)
 
 pBRLO :: Parser Instruction
 pBRLO = do
-    cistring "BRLO" >> space
+    cistring "BRLO" >> space1
     label <- pLabelValue
     return (BRLO label)
 
 pBRLT :: Parser Instruction
 pBRLT = do
-    cistring "BRLT" >> space
+    cistring "BRLT" >> space1
     label <- pLabelValue
     return (BRLT label)
 
 pBRMI :: Parser Instruction
 pBRMI = do
-    cistring "BRMI" >> space
+    cistring "BRMI" >> space1
     label <- pLabelValue
     return (BRMI label)
 
 pBRNE :: Parser Instruction
 pBRNE = do
-    cistring "BRNE" >> space
+    cistring "BRNE" >> space1
     label <- pLabelValue
     return (BRNE label)
 
 pBRPL :: Parser Instruction
 pBRPL = do
-    cistring "BRPL" >> space
+    cistring "BRPL" >> space1
     label <- pLabelValue
     return (BRPL label)
 
 pBRSH :: Parser Instruction
 pBRSH = do
-    cistring "BRSH" >> space
+    cistring "BRSH" >> space1
     label <- pLabelValue
     return (BRSH label)
 
 pBRTC :: Parser Instruction
 pBRTC = do
-    cistring "BRTC" >> space
+    cistring "BRTC" >> space1
     label <- pLabelValue
     return (BRTC label)
 
 pBRTS :: Parser Instruction
 pBRTS = do
-    cistring "BRTS" >> space
+    cistring "BRTS" >> space1
     label <- pLabelValue
     return (BRTS label)
 
 pBRVC :: Parser Instruction
 pBRVC = do
-    cistring "BRVC" >> space
+    cistring "BRVC" >> space1
     label <- pLabelValue
     return (BRVC label)
 
 pBRVS :: Parser Instruction
 pBRVS = do
-    cistring "BRVS" >> space
+    cistring "BRVS" >> space1
     label <- pLabelValue
     return (BRVS label)
 
 pCALL :: Parser Instruction
 pCALL = do
-    cistring "CALL" >> space
+    cistring "CALL" >> space1
     label <- pLabelValue
     return (CALL label)
 
 pCBR :: Parser Instruction
 pCBR = do
-    cistring "CBR" >> space
+    cistring "CBR" >> space1
     rd <- pRegister
     pComma
     CBR rd <$> pWord8
 
 pCLC :: Parser Instruction
 pCLC = do
-    cistring "CLC" >> space
+    cistring "CLC" >> (space1 <|> eof)
     return CLC
 
 pCLH :: Parser Instruction
 pCLH = do
-    cistring "CLH" >> space
+    cistring "CLH" >> (space1 <|> eof)
     return CLH
 
 pCLI :: Parser Instruction
 pCLI = do
-    cistring "CLI" >> space
+    cistring "CLI" >> (space1 <|> eof)
     return CLI
 
 pCLN :: Parser Instruction
 pCLN = do
-    cistring "CLN" >> space
+    cistring "CLN" >> (space1 <|> eof)
     return CLN
 
 pCLR :: Parser Instruction
 pCLR = do
-    cistring "CLR" >> space
+    cistring "CLR" >> (space1 <|> eof)
     CLR <$> pRegister
 
 pCLS :: Parser Instruction
 pCLS = do
-    cistring "CLS" >> space
+    cistring "CLS" >> (space1 <|> eof)
     return CLS
 
 pCLT :: Parser Instruction
 pCLT = do
-    cistring "CLT" >> space
+    cistring "CLT" >> (space1 <|> eof)
     return CLT
 
 pCLV :: Parser Instruction
 pCLV = do
-    cistring "CLV" >> space
+    cistring "CLV" >> (space1 <|> eof)
     return CLV
 
 pCLZ :: Parser Instruction
 pCLZ = do
-    cistring "CLZ" >> space
+    cistring "CLZ" >> (space1 <|> eof)
     return CLZ
-
 
 pCOM :: Parser Instruction
 pCOM = do
-    cistring "COM" >> space
+    cistring "COM" >> space1
     COM <$> pRegister
 
 pCP :: Parser Instruction
 pCP = do
-    cistring "CP" >> space
+    cistring "CP" >> space1
     rd <- pRegister
     pComma
     CP rd <$> pRegister
 
 pCPC :: Parser Instruction
 pCPC = do
-    cistring "CPC" >> space
+    cistring "CPC" >> space1
     rd <- pRegister
     pComma
     CPC rd <$> pRegister
 
 pCPI :: Parser Instruction
 pCPI = do
-    cistring "CPI" >> space
+    cistring "CPI" >> space1
     rd <- pRegister
     pComma
     CPI rd <$> pWord8
 
 pCPSE :: Parser Instruction
 pCPSE = do
-    cistring "CPSE" >> space
+    cistring "CPSE" >> space1
     rd <- pRegister
     pComma
     CPSE rd <$> pRegister
 
 pDEC :: Parser Instruction
 pDEC = do
-    cistring "DEC" >> space
+    cistring "DEC" >> space1
     DEC <$> pRegister
 
 pEOR :: Parser Instruction
 pEOR = do
-    cistring "EOR" >> space
+    cistring "EOR" >> space1
     rd <- pRegister
     pComma
     EOR rd <$> pRegister
 
 pINC :: Parser Instruction
 pINC = do
-    cistring "INC" >> space
+    cistring "INC" >> space1
     INC <$> pRegister
 
 pJMP :: Parser Instruction
 pJMP = do
-    cistring "JMP" >> space
+    cistring "JMP" >> space1
     label <- pLabelValue
     return (JMP label)
 
 pLD :: Parser Instruction
 pLD = do
-    cistring "LD" >> space
+    cistring "LD" >> space1
     rd <- pRegister
     pComma
     LD rd <$> (pXRegister <|> pYRegister <|> pZRegister)
 
 pLDI :: Parser Instruction
 pLDI = do
-    cistring "LDI" >> space
+    cistring "LDI" >> space1
     rd <- pRegister
     pComma
     LDI rd <$> pWord8
 
 pLDS :: Parser Instruction
 pLDS = do
-    cistring "LDS" >> space
+    cistring "LDS" >> space1
     rd <- pRegister
     pComma
     LDS rd <$> pWord16
 
 pLSL :: Parser Instruction
 pLSL = do
-    cistring "LSL" >> space
+    cistring "LSL" >> space1
     LSL <$> pRegister
 
 pLSR :: Parser Instruction
 pLSR = do
-    cistring "LSR" >> space
+    cistring "LSR" >> space1
     LSR <$> pRegister
 
 pMOV :: Parser Instruction
 pMOV = do
-    cistring "MOV" >> space
+    cistring "MOV" >> space1
     rd <- pRegister
     pComma
     MOV rd <$> pRegister
 
 pMOVW :: Parser Instruction
 pMOVW = do
-    cistring "MOVW" >> space
+    cistring "MOVW" >> space1
     (reg1, reg2) <- pRegisterPair
     pComma
     (reg3, reg4) <- pRegisterPair
@@ -464,169 +463,169 @@ pMOVW = do
 
 pMUL :: Parser Instruction
 pMUL = do
-    cistring "MUL" >> space
+    cistring "MUL" >> space1
     rd <- pRegister
     pComma
     MUL rd <$> pRegister
 
 pMULS :: Parser Instruction
 pMULS = do
-    cistring "MULS" >> space
+    cistring "MULS" >> space1
     rd <- pRegister
     pComma
     MULS rd <$> pRegister
 
 pNEG :: Parser Instruction
 pNEG = do
-    cistring "NEG" >> space
+    cistring "NEG" >> space1
     NEG <$> pRegister
 
 pNOP :: Parser Instruction
 pNOP = do
-    cistring "NOP" >> space
+    cistring "NOP" >> (space1 <|> eof)
     return NOP
 
 pOR :: Parser Instruction
 pOR = do
-    cistring "OR" >> space
+    cistring "OR" >> space1
     rd <- pRegister
     pComma
     OR rd <$> pRegister
 
 pORI :: Parser Instruction
 pORI = do
-    cistring "ORI" >> space
+    cistring "ORI" >> space1
     rd <- pRegister
     pComma
     ORI rd <$> pWord8
 
 pPOP :: Parser Instruction
 pPOP = do
-    cistring "POP" >> space
+    cistring "POP" >> space1
     POP <$> pRegister
 
 pPUSH :: Parser Instruction
 pPUSH = do
-    cistring "PUSH" >> space
+    cistring "PUSH" >> space1
     PUSH <$> pRegister
 
 pRET :: Parser Instruction
 pRET = do
-    cistring "RET" >> space
+    cistring "RET" >> space1
     return RET
 
 pROL :: Parser Instruction
 pROL = do
-    cistring "ROL" >> space
+    cistring "ROL" >> space1
     ROL <$> pRegister
 
 pROR :: Parser Instruction
 pROR = do
-    cistring "ROR" >> space
+    cistring "ROR" >> space1
     ROR <$> pRegister
 
 pSBC :: Parser Instruction
 pSBC = do
-    cistring "SBC" >> space
+    cistring "SBC" >> space1
     rd <- pRegister
     pComma
     SBC rd <$> pRegister
 
 pSBRC :: Parser Instruction
 pSBRC = do
-    cistring "SBRC" >> space
+    cistring "SBRC" >> space1
     rd <- pRegister
     pComma
     SBRC rd <$> pDecimal
 
 pSBRS :: Parser Instruction
 pSBRS = do
-    cistring "SBRS" >> space
+    cistring "SBRS" >> space1
     rd <- pRegister
     pComma
     SBRS rd <$> pDecimal
 
 pSEC :: Parser Instruction
 pSEC = do
-    cistring "SEC" >> space
+    cistring "SEC" >> (space1 <|> eof)
     return SEC
 
 pSEH :: Parser Instruction
 pSEH = do
-    cistring "SEH" >> space
+    cistring "SEH" >> (space1 <|> eof)
     return SEH
 
 pSEI :: Parser Instruction
 pSEI = do
-    cistring "SEI" >> space
+    cistring "SEI" >> (space1 <|> eof)
     return SEI
 
 pSEN :: Parser Instruction
 pSEN = do
-    cistring "SEN" >> space
+    cistring "SEN" >> (space1 <|> eof)
     return SEN
 
 pSER :: Parser Instruction
 pSER = do
-    cistring "SER" >> space
+    cistring "SER" >> (space1 <|> eof)
     SER <$> pRegister
 
 pSES :: Parser Instruction
 pSES = do
-    cistring "SES" >> space
+    cistring "SES" >> (space1 <|> eof)
     return SES
 
 pSET :: Parser Instruction
 pSET = do
-    cistring "SET" >> space
+    cistring "SET" >> (space1 <|> eof)
     return SET
 
 pSEV :: Parser Instruction
 pSEV = do
-    cistring "SEV" >> space
+    cistring "SEV" >> (space1 <|> eof)
     return SEV
 
 pSEZ :: Parser Instruction
 pSEZ = do
-    cistring "SEZ" >> space
+    cistring "SEZ" >> (space1 <|> eof)
     return SEZ
 
 pST :: Parser Instruction
 pST = do
-    cistring "ST" >> space
+    cistring "ST" >> space1
     x <- (pXRegister <|> pYRegister <|> pZRegister)
     pComma
     ST x <$> pRegister
 
 pSTS :: Parser Instruction
 pSTS = do
-    cistring "STS" >> space
+    cistring "STS" >> space1
     k <- pWord16
     pComma
     STS k <$> pRegister
 
 pSUB :: Parser Instruction
 pSUB = do
-    cistring "SUB" >> space
+    cistring "SUB" >> space1
     rd <- pRegister
     pComma
     SUB rd <$> pRegister
 
 pSUBI :: Parser Instruction
 pSUBI = do
-    cistring "SUBI" >> space
+    cistring "SUBI" >> space1
     rd <- pRegister
     pComma
     SUBI rd <$> pWord8
 
 pSWAP :: Parser Instruction
 pSWAP = do
-    cistring "SWAP" >> space
+    cistring "SWAP" >> space1
     SWAP <$> pRegister
 
 pTST :: Parser Instruction
 pTST = do
-    cistring "TST" >> space
+    cistring "TST" >> space1
     TST <$> pRegister
 
 -- Main parsers

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -64,7 +64,7 @@ pHexDigit = oneOf ['0'..'9'] <|> oneOf ['a'..'f'] <|> oneOf ['A'..'F']
 pFlagDigit :: Parser Int
 pFlagDigit = digitToInt <$> oneOf ['0'..'7']
 
-pHexWord8 :: Parser Word8
+pHexWord8 :: Parser Int
 pHexWord8 = do
     string "0x" <|> string "$"
     hexDigits <- some pHexDigit
@@ -72,7 +72,7 @@ pHexWord8 = do
         [(value, "")] -> return (fromInteger value)
         _ -> fail "Invalid hexadecimal number format"
 
-pDecWord8 :: Parser Word8
+pDecWord8 :: Parser Int
 pDecWord8 = do
     digits <- some digitChar
     return $ read digits
@@ -81,7 +81,7 @@ pWord8 :: Parser Word8
 pWord8 = do
     byte <- pHexWord8 <|> pDecWord8 <?> "number in hexadecimal or decimal format"
     if 0 <= byte && byte <= 0xFF then
-        return byte
+        return (fromIntegral byte)
     else
         fail "Value out of range for a byte"
 

--- a/test/MainTests.hs
+++ b/test/MainTests.hs
@@ -924,10 +924,10 @@ testMovw state = do
     let regValue = registers state ! 17
     regValue `shouldBe` 0xef
 
-    let regValue = registers state ! 25
+    let regValue = registers state ! 26
     regValue `shouldBe` 0xbe
 
-    let regValue = registers state ! 26
+    let regValue = registers state ! 27
     regValue `shouldBe` 0xef
 
     -- Status flags

--- a/test_files/bubblesort.asm
+++ b/test_files/bubblesort.asm
@@ -21,11 +21,11 @@ _main:
 
     CALL func_fill_array
 
-    ; Prepare registers for bubblesort - R12:11 for the start of the list, R26:27 for traversing the list
+    ; Prepare registers for bubblesort - R12:13 for the start of the list, R26:27 for traversing the list
     ; and R8:9 for the length of the list
-    CLR R11
+    CLR R12
     LDI R25, 0x01
-    MOV R12, R25
+    MOV R13, R25
 
     LDI R26, 0x00
     LDI R27, 0x00
@@ -49,7 +49,7 @@ func_fill_array:
     RET
 
 ;; Bubble Sort function - sorts a given list of unsigned integers in-place
-; R12:11 - start address of the list to sort
+; R12:13 - start address of the list to sort
 ; R9:8 - length of the list
 ; No return value
 func_bubblesort:
@@ -57,7 +57,7 @@ func_bubblesort:
     PUSH R19
     PUSH R18
     PUSH R12
-    PUSH R11
+    PUSH R13
     PUSH R9
     PUSH R8
     PUSH R27
@@ -73,8 +73,8 @@ func_bubblesort:
     LDI R29, 0x00
 OUTER_LOOP:
 
-    MOVW R19:18, R9:8   ; Inner loop counter
-    MOVW R27:26, R12:11 ; Reset X to point at the start of the array
+    MOVW R18, R8   ; Inner loop counter
+    MOVW R26, R12 ; Reset X to point at the start of the array
 
     LDI R20, 0x00  ; Clear swap flag by setting R20 to 0
 
@@ -115,7 +115,7 @@ NO_SWAP:
     POP R27
     POP R8
     POP R9
-    POP R11
+    POP R13
     POP R12
     POP R18
     POP R19

--- a/test_files/collatz.asm
+++ b/test_files/collatz.asm
@@ -36,7 +36,7 @@ collatz_start:
 
 collatz_odd:
     ; Odd case: X = 3 * X + 1
-    MOVW R18:19, R26:27      ; Copy X (R26:R27) to R18:R19 for multiplication
+    MOVW R18, R26      ; Copy X (R26:R27) to R18:R19 for multiplication
     ADD R26, R26       ; Double low byte
     ADC R27, R27       ; Double high byte with carry
     ADD R26, R18       ; Add original low byte

--- a/test_files/factorial.asm
+++ b/test_files/factorial.asm
@@ -24,7 +24,7 @@ func_factorial:
 
 factorial_loop:
     MUL R16, R24 ; Multiply R16 to the accumulator
-    MOVW R25:24, R1:0 ; Move result to the accumulator
+    MOVW R24, R0 ; Move result to the accumulator
     DEC R16
     BRNE factorial_loop ; If R16 is not 0 yet, we do another loop
 

--- a/test_files/test_movw.asm
+++ b/test_files/test_movw.asm
@@ -1,4 +1,4 @@
     LDI R16, 0xBE
     LDI R17, 0xEF
 
-    MOVW R26:25, R17:16
+    MOVW R26, R16


### PR DESCRIPTION
\+ Add nice error reporting with some custom errors
\+ Add support for writing numbers in decimal format too
\* Abstract away label values in a parser and some more comments
\* Change MOVW instruction to be the same as ADIW, although the documentation is wrong in this regard.
\* Change README to check "better error reporting"
\- Remove the dumb "Error assembling the program" message

## MOVW
Although the AVR documentation from Microchip uses this as an example for MOVW:
```asm
movw r17:16,r1:r0         ; Copy r1:r0 to r17:r16
call check                ; Call subroutine
```

You will notice that they themselves are not consistent, as ADIW, an instruction that works with words as well, uses this syntax instead: `ADIW R26`, and the R27 is implied, as the hardware does not allow it to be anything else. Even weirder, there is a typo in that example: `r1:r0` has the `r` for both the high and low register, but `r17:16` only has it for the high register.

Indeed, upon trying different ways of writing this instruction and compiling with AVRA, only `MOVW R16, R0` is accepted, so this is how we will parse it as well, since we want the emulator to be used in conjunction with AVRA.

## Error reporting
We still may need to add more errors and check for more, but this is how the current error reporting looks:
```
11:6:
   |
11 | MOV 1, R27
   |      ^
Invalid register label
```

Which I think is quite nice and user-friendly.

This closes #35 