### PR TITLE
Implement and test XCH instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ You can find test assembly programs in the `test_files/` directory in the root o
   - `SUBI` – Subtract an immediate value from a register.
   - `SWAP` – Swap nibbles of register.
   - `TST` – Test if a register is zero or negative.
-
+  - `XCH` – Exchanges one byte indirect between the register and data space.
+  
 ## Roadmap
   - [x] Configurable memory size through command line arguments.
   - [x] Implement in-memory stack with `PUSH` and `POP` instructions.

--- a/src/Emulator/Core.hs
+++ b/src/Emulator/Core.hs
@@ -97,6 +97,7 @@ executeInstruction mutRegisters mutMemory flags pc sp instruction = do
         SUBI rd k -> subi mutRegisters mutMemory flags sp rd k
         SWAP rd -> swap mutRegisters mutMemory flags sp rd
         TST rd -> tst mutRegisters flags sp rd
+        XCH rd -> xch mutRegisters mutMemory flags sp rd
     return (updatedFlags, pc + fromIntegral relativeJump + 1, updatedSp)
 
 initEmulatorState :: Int -> EmulatorState

--- a/src/Emulator/Instructions.hs
+++ b/src/Emulator/Instructions.hs
@@ -1137,7 +1137,7 @@ tst registers oldStatus sp op1 = do
     return (updatedFlags, 0, sp)
 
 xch :: MutRegisters s -> MutMemory s -> StatusFlags -> StackPointer -> Register -> ST s (StatusFlags, Int, StackPointer)
-xch registers memory oldStatus sp op1 = do
+xch registers memory oldFlags sp op1 = do
     let rdIndex = fromIntegral op1
     rd <- getRegister registers rdIndex
     r31 <- getRegister registers 31
@@ -1146,7 +1146,7 @@ xch registers memory oldStatus sp op1 = do
     memoryValue <- getMemory memory (fromIntegral address16b)
     setMemory registers memory (fromIntegral address16b) rd
     setRegister registers memory rdIndex memoryValue
-    return (oldStatus, 0, sp)
+    return (oldFlags, 0, sp)
 
 -- /////////////////////////////////////////////////////
 -- End instruction implementations 

--- a/src/Emulator/Instructions.hs
+++ b/src/Emulator/Instructions.hs
@@ -125,6 +125,7 @@ data Instruction
     | SUBI Register Word8
     | SWAP Register
     | TST Register
+    | XCH Register
     deriving (Show, Eq)
 
 -- /////////////////////////////////////////////////////
@@ -1134,6 +1135,18 @@ tst registers oldStatus sp op1 = do
         carryFlag = carryFlag oldStatus
     }
     return (updatedFlags, 0, sp)
+
+xch :: MutRegisters s -> MutMemory s -> StatusFlags -> StackPointer -> Register -> ST s (StatusFlags, Int, StackPointer)
+xch registers memory oldStatus sp op1 = do
+    let rdIndex = fromIntegral op1
+    rd <- getRegister registers rdIndex
+    r31 <- getRegister registers 31
+    r30 <- getRegister registers 30
+    let address16b = (fromIntegral r31 :: Word16) `shiftL` 8 + (fromIntegral r30 :: Word16)
+    memoryValue <- getMemory memory (fromIntegral address16b)
+    setMemory registers memory (fromIntegral address16b) rd
+    setRegister registers memory rdIndex memoryValue
+    return (oldStatus, 0, sp)
 
 -- /////////////////////////////////////////////////////
 -- End instruction implementations 

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -628,6 +628,15 @@ pTST = do
     cistring "TST" >> space1
     TST <$> pRegister
 
+pXCH :: Parser Instruction
+pXCH = do
+    cistring "XCH" >> space1
+    z <- pZRegister
+    pComma
+    if  z == "Z" || z == "z" then
+        XCH <$> pRegister
+    else fail "Pointer register should be 'Z' register"
+
 -- Main parsers
 
 instructionParser :: Parser (Instruction)
@@ -716,7 +725,8 @@ instructionParser = do
         pSUBI,
         pSUB,
         pSWAP,
-        pTST
+        pTST,
+        pXCH
         ]
 
 -- | Parser for comments

--- a/test/MainTests.hs
+++ b/test/MainTests.hs
@@ -245,6 +245,11 @@ main = hspec $ describe "AVR Emulator E2E tests" $ do
         let assemblyFilePath = "test_files/test_ld.asm"
         emulateProgramFromFile assemblyFilePath testLd
 
+    -- test_xch.asm
+    it "Should correctly emulate test_xch.asm and match expected state" $ do
+      let assemblyFilePath = "test_files/test_xch.asm"
+      emulateProgramFromFile assemblyFilePath testXch
+
 -- Checking emulator state for array_merge.asm
 testArrayMerge :: EmulatorState -> IO ()
 testArrayMerge state = do
@@ -1256,3 +1261,26 @@ testEof state = do
     negativeFlag (flags state) `shouldBe` False
     zeroFlag (flags state) `shouldBe` False
     carryFlag (flags state) `shouldBe` False
+
+-- Checking EmulatorState for the "test_xch.asm"
+testXch :: EmulatorState -> IO ()
+testXch state = do
+    -- Memory
+    let memValue = memory state ! 273
+    memValue `shouldBe` 37
+
+    let memValue = memory state ! 274
+    memValue `shouldBe` 0
+
+    -- Registers
+    let regValue = registers state ! 19
+    regValue `shouldBe` 14
+
+    let regValue = registers state ! 25
+    regValue `shouldBe` 5
+
+    let regValue = registers state ! 30
+    regValue `shouldBe` 18
+
+    let regValue = registers state ! 31
+    regValue `shouldBe` 1

--- a/test_files/test_xch.asm
+++ b/test_files/test_xch.asm
@@ -1,0 +1,15 @@
+    LDI ZH, 0x01
+    LDI ZL, 0x11
+    LDI R20, 0x0E
+    ST Z, R20
+    CLR R20
+
+    LDI R19, 0x25
+    XCH Z, R19
+
+    LDI R20, 0x05
+    LDI ZH, 0x01
+    LDI ZL, 0x12
+    ST Z, R20
+    CLR R20
+    XCH Z, R25


### PR DESCRIPTION
Changes:
- can now both parse and execute the `XCH` instruction
- added a test file for the `XCH` instruction
- changed README to include the `XCH` instruction and description

this closes  #14.